### PR TITLE
Basic file upload support

### DIFF
--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -9,6 +9,8 @@ import (
 )
 
 func UploadHandler(w http.ResponseWriter, r *http.Request) {
+	// server will send request containing file data to be saved on server. multiple files and folders to be supported.
+
 	const maxUploadSize = 10 << 30 // 10 GB
 	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
 
@@ -23,6 +25,7 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	for _, fileHeader := range files {
 		// This still gives you the correct relative path (if sent via third argument in append())
+		// currently not being respected in practice. to be fixed.
 		relPath := fileHeader.Filename
 
 		// Debug log

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"io"
 	"log"
 	"net/http"
@@ -70,5 +71,11 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Println("############### UPLOAD FINISH ###############")
 
-	http.Redirect(w, r, "/", http.StatusSeeOther)
+	// http.Redirect(w, r, "/", http.StatusSeeOther)
+	resp := map[string]string{
+		"status":  "ok",
+		"details": "Files Saved successfully to " + destinationPath,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
 }

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -13,37 +13,46 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
 
-	err := r.ParseMultipartForm(32 << 20) // 32MB memory buffer for form parsing only
+	err := r.ParseMultipartForm(32 << 20) // 32MB memory buffer
 	if err != nil {
 		http.Error(w, "File too large or invalid form", http.StatusBadRequest)
 		return
 	}
 
-	file, header, err := r.FormFile("file")
-	if err != nil {
-		http.Error(w, "Error retrieving file", http.StatusBadRequest)
-		return
-	}
-	defer file.Close()
-
-	filename := filepath.Base(header.Filename)
-	outPath := filepath.Join("uploads", filename)
-
-	outFile, err := os.Create(outPath)
-	if err != nil {
-		http.Error(w, "Unable to save file", http.StatusInternalServerError)
-		return
-	}
-	defer outFile.Close()
-
-	_, err = io.Copy(outFile, file) // streaming, minimal memory usage
-	if err != nil {
-		http.Error(w, "Error writing file", http.StatusInternalServerError)
+	// Handle multiple files under the field name "files"
+	files := r.MultipartForm.File["files"]
+	if len(files) == 0 {
+		http.Error(w, "No files uploaded", http.StatusBadRequest)
 		return
 	}
 
-	log.Printf("Uploaded %s successfully!", filename)
+	for _, header := range files {
+		file, err := header.Open()
+		if err != nil {
+			http.Error(w, "Error retrieving file", http.StatusBadRequest)
+			return
+		}
+		defer file.Close()
 
-	// Redirect back or send a response
+		filename := filepath.Base(header.Filename)
+		outPath := filepath.Join("uploads", filename)
+
+		outFile, err := os.Create(outPath)
+		if err != nil {
+			http.Error(w, "Unable to save file", http.StatusInternalServerError)
+			return
+		}
+		defer outFile.Close()
+
+		_, err = io.Copy(outFile, file)
+		if err != nil {
+			http.Error(w, "Error writing file", http.StatusInternalServerError)
+			return
+		}
+
+		log.Printf("Uploaded %s successfully!", filename)
+	}
+
+	// Redirect or respond after all files are processed
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -23,7 +23,9 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 	form := r.MultipartForm
 	log.Print("############### UPLOAD START ############### \nReceived save request: \n", form)
 	files := form.File["files"]
-	paths := form.Value["paths"] // Slice of relative paths, same order as files
+	paths := form.Value["paths"]                    // Slice of relative paths, same order as files
+	destinationPath := form.Value["destination"][0] // Path currently viewed by client. Only one provided.
+	log.Println("Requested save directory: ", destinationPath)
 	log.Println("Relative path count: ", len(paths))
 
 	for i, fileHeader := range files {
@@ -36,7 +38,7 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 
 		// Sanitize and ensure full path
 		relPath = filepath.Clean(relPath)
-		uploadPath := filepath.Join("uploads", relPath)
+		uploadPath := filepath.Join(destinationPath, relPath)
 
 		err := os.MkdirAll(filepath.Dir(uploadPath), os.ModePerm)
 		if err != nil {

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+func UploadHandler(w http.ResponseWriter, r *http.Request) {
+	const maxUploadSize = 10 << 30 // 10 GB
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
+
+	err := r.ParseMultipartForm(32 << 20) // 32MB memory buffer for form parsing only
+	if err != nil {
+		http.Error(w, "File too large or invalid form", http.StatusBadRequest)
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, "Error retrieving file", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	filename := filepath.Base(header.Filename)
+	outPath := filepath.Join("uploads", filename)
+
+	outFile, err := os.Create(outPath)
+	if err != nil {
+		http.Error(w, "Unable to save file", http.StatusInternalServerError)
+		return
+	}
+	defer outFile.Close()
+
+	_, err = io.Copy(outFile, file) // streaming, minimal memory usage
+	if err != nil {
+		http.Error(w, "Error writing file", http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("Uploaded %s successfully!", filename)
+
+	// Redirect back or send a response
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -10,49 +10,56 @@ import (
 
 func UploadHandler(w http.ResponseWriter, r *http.Request) {
 	const maxUploadSize = 10 << 30 // 10 GB
-
 	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
 
-	err := r.ParseMultipartForm(32 << 20) // 32MB memory buffer
+	err := r.ParseMultipartForm(32 << 20)
 	if err != nil {
 		http.Error(w, "File too large or invalid form", http.StatusBadRequest)
 		return
 	}
 
-	// Handle multiple files under the field name "files"
-	files := r.MultipartForm.File["files"]
-	if len(files) == 0 {
-		http.Error(w, "No files uploaded", http.StatusBadRequest)
-		return
-	}
+	form := r.MultipartForm
+	files := form.File["files"]
 
-	for _, header := range files {
-		file, err := header.Open()
+	for _, fileHeader := range files {
+		// This still gives you the correct relative path (if sent via third argument in append())
+		relPath := fileHeader.Filename
+
+		// Debug log
+		log.Println("Received file with relPath:", relPath)
+
+		// Sanitize and ensure full path
+		relPath = filepath.Clean(relPath)
+		uploadPath := filepath.Join("uploads", relPath)
+
+		err := os.MkdirAll(filepath.Dir(uploadPath), os.ModePerm)
 		if err != nil {
-			http.Error(w, "Error retrieving file", http.StatusBadRequest)
+			http.Error(w, "Unable to create directories", http.StatusInternalServerError)
+			return
+		}
+
+		file, err := fileHeader.Open()
+		if err != nil {
+			http.Error(w, "Error opening file", http.StatusInternalServerError)
 			return
 		}
 		defer file.Close()
 
-		filename := filepath.Base(header.Filename)
-		outPath := filepath.Join("uploads", filename)
-
-		outFile, err := os.Create(outPath)
+		outFile, err := os.Create(uploadPath)
 		if err != nil {
-			http.Error(w, "Unable to save file", http.StatusInternalServerError)
+			http.Error(w, "Unable to create file", http.StatusInternalServerError)
 			return
 		}
 		defer outFile.Close()
 
 		_, err = io.Copy(outFile, file)
 		if err != nil {
-			http.Error(w, "Error writing file", http.StatusInternalServerError)
+			http.Error(w, "Error saving file", http.StatusInternalServerError)
 			return
 		}
 
-		log.Printf("Uploaded %s successfully!", filename)
+		log.Printf("Saved: %s", uploadPath)
 	}
 
-	// Redirect or respond after all files are processed
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -9,7 +9,7 @@ import (
 )
 
 func UploadHandler(w http.ResponseWriter, r *http.Request) {
-	// server will send request containing file data to be saved on server. multiple files and folders to be supported.
+	// cleint will send request containing file data to be saved on server. This handles saving it. multiple files and folders to be supported.
 
 	const maxUploadSize = 10 << 30 // 10 GB
 	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
@@ -21,12 +21,15 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	form := r.MultipartForm
+	log.Print("############### UPLOAD START ############### \nReceived save request: \n", form)
 	files := form.File["files"]
+	paths := form.Value["paths"] // Slice of relative paths, same order as files
+	log.Println("Relative path count: ", len(paths))
 
-	for _, fileHeader := range files {
+	for i, fileHeader := range files {
 		// This still gives you the correct relative path (if sent via third argument in append())
 		// currently not being respected in practice. to be fixed.
-		relPath := fileHeader.Filename
+		relPath := paths[i] // Get matching relative path
 
 		// Debug log
 		log.Println("Received file with relPath:", relPath)
@@ -63,6 +66,7 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 
 		log.Printf("Saved: %s", uploadPath)
 	}
+	log.Println("############### UPLOAD FINISH ###############")
 
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"os"
 
 	"nas-go/handlers"
 )
@@ -23,6 +24,8 @@ func main() {
 		A browser request to /static/script.js
 		Becomes ./static/script.js on disk
 	*/
+	http.HandleFunc("/upload", handlers.UploadHandler)
+	os.MkdirAll("uploads", os.ModePerm)
 
 	println("Server started at http://localhost:8080")
 	http.ListenAndServe("0.0.0.0:8080", nil) // listen on all interfaces and accept from any IP address.

--- a/static/script.js
+++ b/static/script.js
@@ -48,6 +48,9 @@ function goToDirectory(directory) {
             document.getElementById("file-list").innerHTML = html;
             document.getElementById("up-button-response").textContent = "" // clear error box
             currentDirectory = directory; // update global tracker with new current location
+            console.log("Switched to directory: ", currentDirectory);
+            document.getElementById("current-directory-display").textContent = currentDirectory // display current directory
+            
         })
         .catch(err => {
             console.error("Error updating file list:", err);

--- a/static/script.js
+++ b/static/script.js
@@ -7,6 +7,8 @@
 let currentDirectory = "./storage-directory/"; // initial value - store to allow traversing backwards.
 
 function submitFilename() {
+    // function for handling file name submit button, which provides example response from server of the name.
+    // jump point for file requests/DL?
     const filename = document.getElementById("filename").value;
     console.log("submitFilename triggered, filename:", filename); // This should log to the browser console
     fetch("/api/submit", {
@@ -28,6 +30,7 @@ function submitFilename() {
 
 function goToDirectory(directory) {
     // sends get request for files in a particular directory. if none provided, go up a level
+    // ***NOTE: if not seeing changes, ENSURE CACHING TURNED OFF ON BROWSER! 
     console.log("Clicked to go to directory: ", directory);
     if (directory == "" && currentDirectory == "./storage-directory/"){
         // Asking to go up at top level. Have to refuse. 

--- a/static/script.js
+++ b/static/script.js
@@ -4,7 +4,10 @@
 
 //Log entries can be removed on project completion as they only impact chrome's dev tools console. 
 
-let currentDirectory = "./storage-directory/"; // initial value - store to allow traversing backwards.
+// let currentDirectory = "./storage-directory/"; // initial value - store to allow traversing backwards.
+window.sharedData = {
+    currentDirectory: "./storage-directory/"
+};
 
 function submitFilename() {
     // function for handling file name submit button, which provides example response from server of the name.
@@ -32,14 +35,14 @@ function goToDirectory(directory) {
     // sends get request for files in a particular directory. if none provided, go up a level
     // ***NOTE: if not seeing changes, ENSURE CACHING TURNED OFF ON BROWSER! 
     console.log("Clicked to go to directory: ", directory);
-    if (directory == "" && currentDirectory == "./storage-directory/"){
+    if (directory == "" && window.sharedData.currentDirectory == "./storage-directory/"){
         // Asking to go up at top level. Have to refuse. 
         document.getElementById("up-button-response").textContent = "Cannot go up at top level"
         return
     }
     else if (directory == ""){
         // none provided means go up one level
-        directory = currentDirectory
+        directory = window.sharedData.currentDirectory
         directory = directory.replace(/\/$/, ''); // Remove trailing slash
         let parts = directory.split('/'); // split current path into parts
         parts.pop(); // Remove last segment (current folder)
@@ -50,9 +53,9 @@ function goToDirectory(directory) {
         .then(html => {
             document.getElementById("file-list").innerHTML = html;
             document.getElementById("up-button-response").textContent = "" // clear error box
-            currentDirectory = directory; // update global tracker with new current location
-            console.log("Switched to directory: ", currentDirectory);
-            document.getElementById("current-directory-display").textContent = currentDirectory // display current directory
+            window.sharedData.currentDirectory = directory; // update global tracker with new current location
+            console.log("Switched to directory: ", window.sharedData.currentDirectory);
+            document.getElementById("current-directory-display").textContent = window.sharedData.currentDirectory // display current directory
             
         })
         .catch(err => {

--- a/static/upload.js
+++ b/static/upload.js
@@ -41,6 +41,9 @@
 
 
 function uploadFiles() {
+    // based on files selected, will upload them to the server. Allows regular files or folders.
+    // TODO: for folders, make it respect the directory structure instead of unpacking them. maybe server side issue.
+    // also, allow providing a directory or using the current directory to tell the server where to put them!
     const files = document.getElementById("fileInput").files;
     const folderFiles = document.getElementById("folderInput").files;
 

--- a/static/upload.js
+++ b/static/upload.js
@@ -1,0 +1,74 @@
+// function uploadFile() {
+//     const file = document.getElementById("fileInput").files[0];
+//     if (!file) return;
+
+//     const chunkSize = 1024 * 1024; // 1MB
+//     const totalChunks = Math.ceil(file.size / chunkSize);
+
+//     let currentChunk = 0;
+//     const status = document.getElementById("status");
+
+//     function uploadNext() {
+//         const start = currentChunk * chunkSize;
+//         const end = Math.min(file.size, start + chunkSize);
+//         const chunk = file.slice(start, end);
+
+//         const formData = new FormData();
+//         formData.append("filename", file.name);
+//         formData.append("chunkIndex", currentChunk);
+//         formData.append("totalChunks", totalChunks);
+//         formData.append("chunk", chunk);
+
+//         fetch("/upload", {
+//             method: "POST",
+//             body: formData
+//         }).then(() => {
+//             currentChunk++;
+//             if (currentChunk < totalChunks) {
+//                 uploadNext();
+//                 status.textContent = `Uploading chunk ${currentChunk}/${totalChunks}`;
+//             } else {
+//                 status.textContent = "Upload complete!";
+//             }
+//         }).catch(err => {
+//             status.textContent = "Upload failed: " + err;
+//         });
+//     }
+
+//     uploadNext();
+// }
+
+
+function uploadFile() {
+    const file = document.getElementById("fileInput").files[0];
+    if (!file) {
+        alert("Please select a file first.");
+        return;
+    }
+
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", "/upload", true);
+
+    // Progress event
+    xhr.upload.onprogress = function (e) {
+        if (e.lengthComputable) {
+            const percent = Math.round((e.loaded / e.total) * 100);
+            document.getElementById("progressBar").value = percent;
+            document.getElementById("statusText").textContent = `Uploading: ${percent}%`;
+        }
+    };
+
+    // Completion
+    xhr.onload = function () {
+        if (xhr.status == 200) {
+            document.getElementById("statusText").textContent = "Upload complete!";
+        } else {
+            document.getElementById("statusText").textContent = `Error: ${xhr.statusText}`;
+        }
+    };
+
+    // Send file
+    const formData = new FormData();
+    formData.append("file", file);
+    xhr.send(formData);
+}

--- a/static/upload.js
+++ b/static/upload.js
@@ -85,8 +85,9 @@ function uploadFiles() {
     for (let i = 0; i < folderFiles.length; i++) {
         const file = folderFiles[i];
         console.log("appending file to formdata with relative path: ", file.webkitRelativePath); // This should log to the browser console
-        formData.append("files", file, file.webkitRelativePath); // Preserve folder structure
-        
+        // formData.append("files", file, file.webkitRelativePath); // Preserve folder structure
+        formData.append("files", file); // Go's fileHeader.Filename strips path from the base name and discards. have to seperately add it.
+        formData.append("paths", file.webkitRelativePath); // Preserve folder structure.        
     }
 
     // Send the files

--- a/static/upload.js
+++ b/static/upload.js
@@ -68,6 +68,22 @@ function uploadFiles() {
     xhr.onload = function () {
         if (xhr.status == 200) {
             document.getElementById("statusText").textContent = "Upload complete!";
+
+            // refresh view
+            fetch(`/filelist?dir=${window.sharedData.currentDirectory}`)
+            .then(response => response.text())
+            .then(html => {
+                document.getElementById("file-list").innerHTML = html;
+                document.getElementById("up-button-response").textContent = "" // clear error box
+                // window.sharedData.currentDirectory = directory; // update global tracker with new current location
+                console.log("Refreshed directory: ", window.sharedData.currentDirectory);
+                document.getElementById("current-directory-display").textContent = window.sharedData.currentDirectory // display current directory
+                
+            })
+            .catch(err => {
+                console.error("Error updating file list:", err);
+            });
+
         } else {
             document.getElementById("statusText").textContent = `Error: ${xhr.statusText}`;
         }
@@ -93,5 +109,6 @@ function uploadFiles() {
 
     // Send the files
     xhr.send(formData);
+
 }
 

--- a/static/upload.js
+++ b/static/upload.js
@@ -42,8 +42,10 @@
 
 function uploadFiles() {
     const files = document.getElementById("fileInput").files;
-    if (!files.length) {
-        alert("Please select at least one file.");
+    const folderFiles = document.getElementById("folderInput").files;
+
+    if (files.length === 0 && folderFiles.length === 0) {
+        alert("Please select at least one file or folder.");
         return;
     }
 
@@ -68,10 +70,23 @@ function uploadFiles() {
         }
     };
 
-    // Send file
+    // Prepare FormData
     const formData = new FormData();
+
+    // Add regular files
     for (let i = 0; i < files.length; i++) {
         formData.append("files", files[i]); // Multiple files under the same key
     }
+
+    // Add folder files with their relative paths
+    for (let i = 0; i < folderFiles.length; i++) {
+        const file = folderFiles[i];
+        console.log("appending file to formdata with relative path: ", file.webkitRelativePath); // This should log to the browser console
+        formData.append("files", file, file.webkitRelativePath); // Preserve folder structure
+        
+    }
+
+    // Send the files
     xhr.send(formData);
 }
+

--- a/static/upload.js
+++ b/static/upload.js
@@ -89,6 +89,7 @@ function uploadFiles() {
         formData.append("files", file); // Go's fileHeader.Filename strips path from the base name and discards. have to seperately add it.
         formData.append("paths", file.webkitRelativePath); // Preserve folder structure.        
     }
+    formData.append("destination", window.sharedData.currentDirectory); // Set the upload destination to currently viewed dir.  
 
     // Send the files
     xhr.send(formData);

--- a/static/upload.js
+++ b/static/upload.js
@@ -39,10 +39,11 @@
 // }
 
 
-function uploadFile() {
-    const file = document.getElementById("fileInput").files[0];
-    if (!file) {
-        alert("Please select a file first.");
+
+function uploadFiles() {
+    const files = document.getElementById("fileInput").files;
+    if (!files.length) {
+        alert("Please select at least one file.");
         return;
     }
 
@@ -69,6 +70,8 @@ function uploadFile() {
 
     // Send file
     const formData = new FormData();
-    formData.append("file", file);
+    for (let i = 0; i < files.length; i++) {
+        formData.append("files", files[i]); // Multiple files under the same key
+    }
     xhr.send(formData);
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
     <h1>File Listing</h1>
+    <p>The directory is: <span id="current-directory-display">./storage-directory/</span></p>
     <button onclick="goToDirectory('')">Up One Level</button>
     <p id="up-button-response"></p>
     <ul id="file-list">

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,9 +27,16 @@
         <button type="submit">Upload</button>
     </form>
     <p id="status"></p> -->
-    <h2>Upload a File</h2>
+    <h2>Upload Files and Folders</h2>
 
-    <input type="file" id="fileInput" multiple>
+    <label>Select Files:
+        <input type="file" id="fileInput" multiple>
+    </label>
+
+    <label>Select Folder:
+        <input type="file" id="folderInput" webkitdirectory multiple>
+    </label>
+
     <button onclick="uploadFiles()">Upload</button>
 
     <div style="margin-top: 10px;">

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,24 @@
     <input type="text" id="filename" placeholder="Enter filename">
     <button onclick="submitFilename()">Submit</button>
     <p id="response"></p>
-    
+
+    <!-- <form action="/upload" method="POST" enctype="multipart/form-data">
+        <input type="file" name="file" required>
+        <button type="submit">Upload</button>
+    </form>
+    <p id="status"></p> -->
+    <h2>Upload a File</h2>
+
+    <input type="file" id="fileInput" />
+    <button onclick="uploadFile()">Upload</button>
+
+    <div style="margin-top: 10px;">
+        <progress id="progressBar" value="0" max="100" style="width: 100%;"></progress>
+        <p id="statusText">Waiting for upload...</p>
+    </div>
+
+    <script src="/static/upload.js"></script>
+
 </body>
 </html>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,8 +29,8 @@
     <p id="status"></p> -->
     <h2>Upload a File</h2>
 
-    <input type="file" id="fileInput" />
-    <button onclick="uploadFile()">Upload</button>
+    <input type="file" id="fileInput" multiple>
+    <button onclick="uploadFiles()">Upload</button>
 
     <div style="margin-top: 10px;">
         <progress id="progressBar" value="0" max="100" style="width: 100%;"></progress>


### PR DESCRIPTION
This branch added basic file upload support, allowing the client to provide files and folders to be saved on the server:
- uploading single files or folders.
- structure preservation of uploaded folders.
- added readout of currently viewed server directory to homepage
- dynamic save destination based on currently viewed directory on the client.
- added automatic reload of the currently viewed directory after upload to reflect changes immediately.
- tested working for nested files and folders, as well as multiple files.